### PR TITLE
fix: Rework interface so conversion to python works correctly in JSII

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,7 +9,7 @@
 ```typescript
 import { ManagedInstanceRole } from '@renovosolutions/cdk-library-managed-instance-role'
 
-new ManagedInstanceRole(scope: Construct, id: string, props: IManagedInstanceRoleProps)
+new ManagedInstanceRole(scope: Construct, id: string, props: ManagedInstanceRoleProps)
 ```
 
 ##### `scope`<sup>Required</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole.parameter.scope"></a>
@@ -26,7 +26,7 @@ new ManagedInstanceRole(scope: Construct, id: string, props: IManagedInstanceRol
 
 ##### `props`<sup>Required</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole.parameter.props"></a>
 
-- *Type:* [`@renovosolutions/cdk-library-managed-instance-role.IManagedInstanceRoleProps`](#@renovosolutions/cdk-library-managed-instance-role.IManagedInstanceRoleProps)
+- *Type:* [`@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRoleProps`](#@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRoleProps)
 
 ---
 
@@ -45,18 +45,19 @@ public readonly instanceProfile: CfnInstanceProfile;
 ---
 
 
+## Structs <a name="Structs"></a>
 
+### ManagedInstanceRoleProps <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRoleProps"></a>
 
-## Protocols <a name="Protocols"></a>
+#### Initializer <a name="[object Object].Initializer"></a>
 
-### IManagedInstanceRoleProps <a name="@renovosolutions/cdk-library-managed-instance-role.IManagedInstanceRoleProps"></a>
+```typescript
+import { ManagedInstanceRoleProps } from '@renovosolutions/cdk-library-managed-instance-role'
 
-- *Implemented By:* [`@renovosolutions/cdk-library-managed-instance-role.IManagedInstanceRoleProps`](#@renovosolutions/cdk-library-managed-instance-role.IManagedInstanceRoleProps)
+const managedInstanceRoleProps: ManagedInstanceRoleProps = { ... }
+```
 
-
-#### Properties <a name="Properties"></a>
-
-##### `domainJoinEnabled`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.IManagedInstanceRoleProps.property.domainJoinEnabled"></a>
+##### `domainJoinEnabled`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRoleProps.property.domainJoinEnabled"></a>
 
 ```typescript
 public readonly domainJoinEnabled: boolean;
@@ -68,7 +69,7 @@ Should the role include directory service access with SSM.
 
 ---
 
-##### `managedPolicies`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.IManagedInstanceRoleProps.property.managedPolicies"></a>
+##### `managedPolicies`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRoleProps.property.managedPolicies"></a>
 
 ```typescript
 public readonly managedPolicies: ManagedPolicy[];
@@ -80,7 +81,7 @@ The managed policies to apply to the role in addition to the default policies.
 
 ---
 
-##### `ssmManagementEnabled`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.IManagedInstanceRoleProps.property.ssmManagementEnabled"></a>
+##### `ssmManagementEnabled`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRoleProps.property.ssmManagementEnabled"></a>
 
 ```typescript
 public readonly ssmManagementEnabled: boolean;
@@ -93,4 +94,6 @@ Should the role include SSM management.
 By default if domainJoinEnabled is true then this role is always included.
 
 ---
+
+
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,38 +1,38 @@
 import * as iam from '@aws-cdk/aws-iam';
 import * as cdk from '@aws-cdk/core';
 
-export interface IManagedInstanceRoleProps {
+export interface ManagedInstanceRoleProps {
   /**
    * The managed policies to apply to the role in addition to the default policies.
    */
-  managedPolicies?: iam.ManagedPolicy[];
+  readonly managedPolicies?: iam.ManagedPolicy[];
   /**
    * Should the role include directory service access with SSM.
    */
-  domainJoinEnabled?: boolean;
+  readonly domainJoinEnabled?: boolean;
   /**
    * Should the role include SSM management. By default if domainJoinEnabled is true then this role is always included.
    */
-  ssmManagementEnabled?: boolean;
+  readonly ssmManagementEnabled?: boolean;
 }
 
 export class ManagedInstanceRole extends cdk.Construct {
 
   public readonly instanceProfile: iam.CfnInstanceProfile
 
-  constructor(scope: cdk.Construct, id: string, props: IManagedInstanceRoleProps) {
+  constructor(scope: cdk.Construct, id: string, props: ManagedInstanceRoleProps) {
     super(scope, id);
 
     var managedPolicies:iam.IManagedPolicy[] = props.managedPolicies === undefined ? [] : props.managedPolicies;
 
-    props.domainJoinEnabled = props.domainJoinEnabled === undefined ||
+    let domainJoinEnabled: boolean = props.domainJoinEnabled === undefined ||
                               props.domainJoinEnabled === true;
-    props.ssmManagementEnabled = props.ssmManagementEnabled === undefined ||
+    let ssmManagementEnabled: boolean = props.ssmManagementEnabled === undefined ||
                                  props.domainJoinEnabled === undefined ||
                                  props.domainJoinEnabled === true ||
                                  props.ssmManagementEnabled === true;
-    if (props.ssmManagementEnabled) { managedPolicies.push(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')); };
-    if (props.domainJoinEnabled) { managedPolicies.push(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMDirectoryServiceAccess')); };
+    if (ssmManagementEnabled) { managedPolicies.push(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore')); };
+    if (domainJoinEnabled) { managedPolicies.push(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMDirectoryServiceAccess')); };
 
     const role = new iam.Role(this, 'role', {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),

--- a/test/__snapshots__/cdk-managed-instance-role.test.ts.snap
+++ b/test/__snapshots__/cdk-managed-instance-role.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Snapshot 1`] = `
+Object {
+  "Resources": Object {
+    "role08402BCB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMDirectoryServiceAccess",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "roleinstanceProfileFF411810": Object {
+      "Properties": Object {
+        "Roles": Array [
+          Object {
+            "Ref": "role08402BCB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+  },
+}
+`;

--- a/test/cdk-managed-instance-role.test.ts
+++ b/test/cdk-managed-instance-role.test.ts
@@ -1,6 +1,15 @@
-import { expect as expectCDK, countResources, haveResource } from '@aws-cdk/assert';
+import { expect as expectCDK, countResources, haveResource, SynthUtils } from '@aws-cdk/assert';
 import * as cdk from '@aws-cdk/core';
 import { ManagedInstanceRole } from '../src/index';
+
+test('Snapshot', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'TestStack', {});
+
+  new ManagedInstanceRole(stack, 'role', {});
+
+  expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+});
 
 test('Simple test', () => {
   const app = new cdk.App();


### PR DESCRIPTION
BREAKING CHANGE: This changes the interface setup so that JSII conversion works as expected. While Typescript had no issue itself the class needed reworked slightly to generate packages in other languages.