### PR TITLE
feat: Make instance profile optional; add name arn and role properties

### DIFF
--- a/API.md
+++ b/API.md
@@ -34,13 +34,51 @@ new ManagedInstanceRole(scope: Construct, id: string, props: ManagedInstanceRole
 
 #### Properties <a name="Properties"></a>
 
-##### `instanceProfile`<sup>Required</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole.property.instanceProfile"></a>
+##### `arn`<sup>Required</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole.property.arn"></a>
+
+```typescript
+public readonly arn: string;
+```
+
+- *Type:* `string`
+
+The role arn.
+
+---
+
+##### `name`<sup>Required</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* `string`
+
+The role name.
+
+---
+
+##### `role`<sup>Required</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole.property.role"></a>
+
+```typescript
+public readonly role: IRole;
+```
+
+- *Type:* [`aws-cdk-lib.aws_iam.IRole`](#aws-cdk-lib.aws_iam.IRole)
+
+The role.
+
+---
+
+##### `instanceProfile`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRole.property.instanceProfile"></a>
 
 ```typescript
 public readonly instanceProfile: CfnInstanceProfile;
 ```
 
 - *Type:* [`aws-cdk-lib.aws_iam.CfnInstanceProfile`](#aws-cdk-lib.aws_iam.CfnInstanceProfile)
+
+The CfnInstanceProfile automatically created for this role.
 
 ---
 
@@ -56,6 +94,19 @@ import { ManagedInstanceRoleProps } from '@renovosolutions/cdk-library-managed-i
 
 const managedInstanceRoleProps: ManagedInstanceRoleProps = { ... }
 ```
+
+##### `createInstanceProfile`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRoleProps.property.createInstanceProfile"></a>
+
+```typescript
+public readonly createInstanceProfile: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* true
+
+Whether or not to associate the role with an instance profile.
+
+---
 
 ##### `domainJoinEnabled`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRoleProps.property.domainJoinEnabled"></a>
 
@@ -78,6 +129,18 @@ public readonly managedPolicies: ManagedPolicy[];
 - *Type:* [`aws-cdk-lib.aws_iam.ManagedPolicy`](#aws-cdk-lib.aws_iam.ManagedPolicy)[]
 
 The managed policies to apply to the role in addition to the default policies.
+
+---
+
+##### `retentionPolicy`<sup>Optional</sup> <a name="@renovosolutions/cdk-library-managed-instance-role.ManagedInstanceRoleProps.property.retentionPolicy"></a>
+
+```typescript
+public readonly retentionPolicy: boolean;
+```
+
+- *Type:* `boolean`
+
+The retention policy for this role.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ The construct defines an interface (`IManagedInstanceRoleProps`) to configure th
 ## Dev
 
 ### Pre-reqs:
-You will need
+
+You will need:
+
 - npm installed on your machine
 - AWS CDK installed on your machine
 - python installed on your machine

--- a/test/cdk-managed-instance-role.test.ts
+++ b/test/cdk-managed-instance-role.test.ts
@@ -20,3 +20,15 @@ test('Simple test', () => {
   Template.fromStack(stack).resourceCountIs('AWS::IAM::Role', 1);
   Template.fromStack(stack).resourceCountIs('AWS::IAM::InstanceProfile', 1);
 });
+
+test('No instance profile test', () => {
+  const app = new App();
+  const stack = new Stack(app, 'TestStack');
+
+  new ManagedInstanceRole(stack, 'ManagedInstanceRole', {
+    createInstanceProfile: false,
+  });
+
+  Template.fromStack(stack).resourceCountIs('AWS::IAM::Role', 1);
+  Template.fromStack(stack).resourceCountIs('AWS::IAM::InstanceProfile', 0);
+});


### PR DESCRIPTION
The instance construct only takes a role not a full instance profile. So in most cases you likely dont need a full instance profile unless its created for another purpose. The default behavior of creating a instance profile remains the same, but is now optionally able to be disabled. In addition this adds other common properties to work with.

Closes #197